### PR TITLE
release/3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.0] - 2023-01-23
+## [3.3.1] - 2023-04-13
+### Changed
+- [#136](https://github.com/unity-sds/unity-data-services/pull/136) fix: uncomment temporal in CMR granules search
+
+## [3.3.0] - 2023-04-11
 ### Added
 - [#134](https://github.com/unity-sds/unity-data-services/pull/134) feat: add option to parse downloading stac from file
 
-## [3.2.0] - 2023-01-23
+## [3.2.0] - 2023-04-11
 ### Added
 - [#131](https://github.com/unity-sds/unity-data-services/pull/131) granules query pagination 
 
-## [3.1.0] - 2023-01-23
+## [3.1.0] - 2023-04-11
 ### Added
 - [#126](https://github.com/unity-sds/unity-data-services/pull/126) reduce pystac length by keeping only data asset
 

--- a/cumulus_lambda_functions/stage_in_out/search_granules_cmr.py
+++ b/cumulus_lambda_functions/stage_in_out/search_granules_cmr.py
@@ -86,12 +86,12 @@ class SearchGranulesCmr(SearchGranulesAbstract):
                 'collection_concept_id': self.__collection_id,
                 'page_num': str(page_num),
                 'page_size': str(page_size),
-                # 'temporal[]': f'{self.__date_from},{self.__date_to}'
+                'temporal[]': f'{self.__date_from},{self.__date_to}'
             }
             cmr_granules_url = f'{self.__cmr_base_url}search/granules.stac'
             response = requests.post(url=cmr_granules_url, headers=header, verify=self.__verify_ssl,
                                      data=request_body)
-            if response.status_code > 400:
+            if response.status_code >= 400:
                 raise RuntimeError(
                     f'Cognito ends in error. status_code: {response.status_code}. url: {cmr_granules_url}. details: {response.text}')
             temp_results = json.loads(response.content.decode('utf-8'))['features']

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extra_requires = ['botocore', 'boto3',]
 
 setup(
     name="cumulus_lambda_functions",
-    version="3.3.0",
+    version="3.3.1",
     packages=find_packages(),
     install_requires=install_requires,
     tests_require=['mock', 'nose', 'sphinx', 'sphinx_rtd_theme', 'coverage', 'pystac', 'python-dotenv', 'jsonschema'],


### PR DESCRIPTION
## [3.3.1] - 2023-04-13
### Changed
- [#136](https://github.com/unity-sds/unity-data-services/pull/136) fix: uncomment temporal in CMR granules search