### PR TITLE
chore: updated version to 5.6.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] - 2023-10-31
+### Fixed
+- [#253](https://github.com/unity-sds/unity-data-services/pull/253) fix: Stage out succeeded when there is an error
+
 ## [5.5.5] - 2023-10-09
 ### Fixed
 - [#252](https://github.com/unity-sds/unity-data-services/pull/252) fix: version update + changelog via pr

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extra_requires = ['botocore', 'boto3',]
 
 setup(
     name="cumulus_lambda_functions",
-    version="5.5.5",
+    version="5.6.0",
     packages=find_packages(),
     install_requires=install_requires,
     tests_require=['mock', 'nose', 'sphinx', 'sphinx_rtd_theme', 'coverage', 'pystac', 'python-dotenv', 'jsonschema'],


### PR DESCRIPTION
## [5.6.0] - 2023-10-31
### Fixed
- [#253](https://github.com/unity-sds/unity-data-services/pull/253) fix: Stage out succeeded when there is an error