### PR TITLE
fix: replace anything not alphanumeric to 3 underscores

### DIFF
--- a/cumulus_lambda_functions/cumulus_wrapper/query_collections.py
+++ b/cumulus_lambda_functions/cumulus_wrapper/query_collections.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import requests
 from cumulus_lambda_functions.cumulus_stac.collection_transformer import CollectionTransformer
@@ -174,6 +175,8 @@ curl --request POST "$CUMULUS_BASEURL/rules" --header "Authorization: Bearer $cu
 }'
         :return:
         """
+        underscore_collection_name = re.sub(r'[^a-zA-Z0-9_]', '___', new_collection["name"])  # replace any character that's not alphanumeric or underscore with 3 underscores
+        LOGGER.debug(f'underscore_collection_name: {underscore_collection_name}')
         rule_body = {
             'workflow': workflow_name,
             'collection': {
@@ -181,7 +184,7 @@ curl --request POST "$CUMULUS_BASEURL/rules" --header "Authorization: Bearer $cu
                 'version': new_collection['version'],
             },
             # 'provider': provider_name,
-            'name': f'{new_collection["name"].replace(":", "___")}___{new_collection["version"]}___rules_sqs',
+            'name': f'{underscore_collection_name}___{new_collection["version"]}___rules_sqs',
             'rule': {
                 # 'type': 'onetime',
                 'type': 'sqs',

--- a/tests/integration_tests/test_old_datatype_end_to_end.py
+++ b/tests/integration_tests/test_old_datatype_end_to_end.py
@@ -42,7 +42,7 @@ class TestOldDataEndToEnd(TestCase):
         self._url_prefix = f'{os.environ.get("UNITY_URL")}/{os.environ.get("UNITY_STAGE", "sbx-uds-dapa")}'
         self.tenant = 'UDS_LOCAL_TEST'  # 'uds_local_test'  # 'uds_sandbox'
         self.tenant_venue = 'DEV'  # 'DEV1'  # 'dev'
-        self.collection_name = 'SNDR_SNPP_ATMS_L1B_OUTPUT'  # 'uds_collection'  # 'sbx_collection'
+        self.collection_name = 'SNDR-SNPP:ATMS@L1B$OUTPUT'  # 'uds_collection'  # 'sbx_collection'
         self.collection_version = '24.02.01.12.00'.replace('.', '')  # '2309141300'
         self.granule_id = 'abcd.1234.efgh.test_file05'
         return

--- a/tests/integration_tests/test_old_datatype_end_to_end.py
+++ b/tests/integration_tests/test_old_datatype_end_to_end.py
@@ -42,7 +42,7 @@ class TestOldDataEndToEnd(TestCase):
         self._url_prefix = f'{os.environ.get("UNITY_URL")}/{os.environ.get("UNITY_STAGE", "sbx-uds-dapa")}'
         self.tenant = 'UDS_LOCAL_TEST'  # 'uds_local_test'  # 'uds_sandbox'
         self.tenant_venue = 'DEV'  # 'DEV1'  # 'dev'
-        self.collection_name = 'SNDR-SNPP:ATMS@L1B$OUTPUT'  # 'uds_collection'  # 'sbx_collection'
+        self.collection_name = 'SNDR-SNPP_ATMS@L1B$OUTPUT'  # 'uds_collection'  # 'sbx_collection'
         self.collection_version = '24.02.01.12.00'.replace('.', '')  # '2309141300'
         self.granule_id = 'abcd.1234.efgh.test_file05'
         return


### PR DESCRIPTION
Closes #324 

cannot accept ":" as it is part of the identifier separator
