### PR TITLE
fix: updated marketplace bucket policy to require SSL

### DIFF
--- a/tf-module/marketplace/s3_bucket_policy.json
+++ b/tf-module/marketplace/s3_bucket_policy.json
@@ -20,6 +20,21 @@
                 "arn:aws:s3:::${s3BucketName}/*",
                 "arn:aws:s3:::${s3BucketName}"
             ]
+        },
+        {
+            "Sid": "AllowSSLRequestsOnly",
+            "Action": "s3:*",
+            "Effect": "Deny",
+            "Resource": [
+                "arn:aws:s3:::${s3BucketName}/*",
+                "arn:aws:s3:::${s3BucketName}"
+            ],
+            "Condition": {
+                "Bool": {
+                     "aws:SecureTransport": "false"
+                }
+            },
+           "Principal": "*"
         }
     ]
 }


### PR DESCRIPTION
## Purpose
- Addresses MCP request as described in https://github.com/unity-sds/unity-project-management/issues/222
## Proposed Changes
- [CHANGE] Bucket policy now requires SSL for all requests
## Issues
- https://github.com/unity-sds/unity-data-services/issues/454
## Testing
- Deployed a new bucket in dev venue using terraform
- Ran stage-out example that writes to new bucket
- Confirmed data exist in new bucket and is cataloged in UDS
