### PR TITLE
feat: push image to ecr

### DIFF
--- a/tf-module/ds_img_to_ecr/ecr1.tf
+++ b/tf-module/ds_img_to_ecr/ecr1.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = var.aws_region
+
+  ignore_tags {
+    key_prefixes = ["gsfc-ngap"]
+  }
+}
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+
+resource "aws_ecr_repository" "repo" {
+  name = var.ecr_repo_name
+  image_tag_mutability = "IMMUTABLE"
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+output "ecr_repo_url" {
+  value = aws_ecr_repository.repo.repository_url
+}
+
+resource "null_resource" "docker_pull_push" {
+  provisioner "local-exec" {
+    command = <<EOT
+      aws ecr get-login-password --region ${var.aws_region} | docker login --username AWS --password-stdin ${aws_ecr_repository.repo.repository_url}
+      docker pull  --platform=linux/amd64 ${var.github_image_url}:${var.image_tag}
+      docker tag ${var.github_image_url}:${var.image_tag} ${aws_ecr_repository.repo.repository_url}:${var.image_tag}
+      docker push ${aws_ecr_repository.repo.repository_url}:${var.image_tag}
+    EOT
+  }
+  depends_on = [aws_ecr_repository.repo]
+}

--- a/tf-module/ds_img_to_ecr/terraform.tf.example
+++ b/tf-module/ds_img_to_ecr/terraform.tf.example
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    region         = "us-west-2"
+    bucket         = "am-uds-dev-cumulus-tf-state"
+    key            = "am-uds-dev-cumulus/ds_img_to_ecr/unity/terraform.tfstate"
+    dynamodb_table = "am-uds-dev-cumulus-tf-locks"
+  }
+}

--- a/tf-module/ds_img_to_ecr/terraform.tfvars.example
+++ b/tf-module/ds_img_to_ecr/terraform.tfvars.example
@@ -1,0 +1,12 @@
+tags = {
+  Venue = "venue-dev",
+  ServiceArea = "ds",
+  CapVersion = "18.0.0"
+  Component = "Cumulus",
+  Proj = "Unity",
+  CreatedBy = "ds",
+  Env = "venue-dev",
+  Stack = "Cumulus"
+}
+aws_region = "us-west-2"
+image_tag="9.6.0"

--- a/tf-module/ds_img_to_ecr/variables.tf
+++ b/tf-module/ds_img_to_ecr/variables.tf
@@ -1,0 +1,26 @@
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}
+variable "tags" {
+  description = "Tags to be applied to Cumulus resources that support tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "github_image_url" {
+  description = "The full URL of the public Docker image on GitHub (e.g., ghcr.io/user/repo)"
+  default = "ghcr.io/unity-sds/unity-data-services"
+  type        = string
+}
+
+variable "image_tag" {
+  description = "The tag of the image to pull from GitHub"
+  type        = string
+}
+
+variable "ecr_repo_name" {
+  description = "The name of the ECR repository"
+  default = "unity-data-services"
+  type        = string
+}


### PR DESCRIPTION
Closes #467 
NOTE-1: if ECR repo already exists before this terraform module, it needs to be deleted, or this terraform needs to use a different repo. 

NOTE-2: This is using local command prompt to push the docker image assuming local environment has aws creds setup and has docker. 