### PR TITLE
Define log level input that sets environment variable

### DIFF
--- a/cwl/stage-in-daac/stage-in.cwl
+++ b/cwl/stage-in-daac/stage-in.cwl
@@ -12,7 +12,7 @@ requirements:
     envDef:
       DOWNLOAD_DIR: $(runtime.outdir)/$(inputs.download_dir)
       STAC_JSON: $(inputs.stac_json)
-      LOG_LEVEL: '10'
+      LOG_LEVEL: $(inputs.log_level)
       PARALLEL_COUNT: '-1'
       DOWNLOAD_RETRY_WAIT_TIME: '30'
       DOWNLOAD_RETRY_TIMES: '5'
@@ -28,6 +28,8 @@ requirements:
 
 inputs:
   download_dir:
+    type: string
+  log_level:
     type: string
   stac_json:
     type: string

--- a/cwl/stage-in-daac/stage-in.cwl
+++ b/cwl/stage-in-daac/stage-in.cwl
@@ -30,6 +30,7 @@ inputs:
   download_dir:
     type: string
   log_level:
+    default: '20'
     type: string
   stac_json:
     type: string

--- a/cwl/stage-out-stac-catalog/stage-out.cwl
+++ b/cwl/stage-out-stac-catalog/stage-out.cwl
@@ -28,6 +28,7 @@ requirements:
 
 inputs:
   log_level:
+    default: '20'
     type: string
   project:
     type: string

--- a/cwl/stage-out-stac-catalog/stage-out.cwl
+++ b/cwl/stage-out-stac-catalog/stage-out.cwl
@@ -17,7 +17,7 @@ requirements:
     envDef:
       STAGING_BUCKET: $(inputs.staging_bucket)
       CATALOG_FILE: '/tmp/outputs/catalog.json'
-      LOG_LEVEL: '10'
+      LOG_LEVEL: $(inputs.log_level)
       PARALLEL_COUNT: '-1'
       OUTPUT_DIRECTORY: $(runtime.outdir)
       PROJECT: $(inputs.project)
@@ -27,6 +27,8 @@ requirements:
       BASE_DIRECTORY: '/tmp/outputs'
 
 inputs:
+  log_level:
+    type: string
   project:
     type: string
   venue:


### PR DESCRIPTION
## Purpose

- Define a log level input that sets the `LOG_LEVEL` environment variable so that SPS can plumb the log level from Airflow user input

## Proposed Changes
- [ADD] `log_level` input parameter

## Issues
- SPS Issue 307: https://github.com/unity-sds/unity-sps/issues/307

## Testing
- Deployed changes to `unity-venue-dev` and tested with SPS Airflow DAG updates. Confirmed log levels were changed based on the `log_level` input parameter. 
- For more details on testing, see this PR: https://github.com/unity-sds/unity-sps/pull/315
