### PR TITLE
Added new field, `isPortalIntegrated`, to the health endpoint metadata.

### DIFF
--- a/tf-module/unity-cumulus/main.tf
+++ b/tf-module/unity-cumulus/main.tf
@@ -185,12 +185,13 @@ resource "aws_ssm_parameter" "health_check_value" {
   type  = "String"
   tier = "Advanced"
   value = jsonencode({
-    healthCheckUrl    = "${var.uds_base_url}/${var.dapa_api_prefix}/collections",
-    landingPageUrl    = "${var.unity_ui_base_url}/data/stac_browser/",
-    componentCategory = "catalogs"
-    componentName     = "Data Catalog",
-    componentType     = "ui"
-    description       = "The STAC Browser to help you browse and search the data catalog for your outputs and other data ingested into the MDPS data system."
+    healthCheckUrl     = "${var.uds_base_url}/${var.dapa_api_prefix}/collections"
+    landingPageUrl     = "${var.unity_ui_base_url}/data/stac_browser/"
+    componentCategory  = "catalogs"
+    componentName      = "Data Catalog"
+    componentType      = "ui"
+    description        = "The STAC Browser to help you browse and search the data catalog for your outputs and other data ingested into the MDPS data system."
+    isPortalIntegrated = false
   })
   tags = var.tags
   overwrite = true


### PR DESCRIPTION
## Purpose

Added the new field, `isPortalIntegrated`, to the health endpoint information. Set the field to be `false` which informs the portal that the respective service, if it is a UI, should be opened in a new window if accessed from the portal's menu.

## Proposed Changes

- [ADD] New metadata field, `isPortalIntegrated` to the health endpoint metadata

## Issues

- https://github.com/unity-sds/ui-ux/issues/8
